### PR TITLE
Wrong class name in v5_1.test_results.__init__.py

### DIFF
--- a/azure-devops/azure/devops/v5_1/test_results/__init__.py
+++ b/azure-devops/azure/devops/v5_1/test_results/__init__.py
@@ -7,7 +7,7 @@
 # --------------------------------------------------------------------------------------------
 
 from .models import *
-from .test_results_client import testResultsClient
+from .test_results_client import TestResultsClient
 
 __all__ = [
     'AggregatedDataForResultTrend',


### PR DESCRIPTION
Just a capitalization mistake.
testResultsClient -> TestResultsClient