### PR TITLE
Test and mark Python 3.12 support. Update setuptools support for >67

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v1

--- a/azure-devops/azure/__init__.py
+++ b/azure-devops/azure/__init__.py
@@ -1,4 +1,0 @@
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for license information.
-# --------------------------------------------------------------------------------------------

--- a/azure-devops/azure/__init__.py
+++ b/azure-devops/azure/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/azure-devops/azure/devops/__init__.py
+++ b/azure-devops/azure/devops/__init__.py
@@ -2,5 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-import pkg_resources
-pkg_resources.declare_namespace(__name__)

--- a/azure-devops/setup.py
+++ b/azure-devops/setup.py
@@ -30,6 +30,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/azure-devops/setup.py
+++ b/azure-devops/setup.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 NAME = "azure-devops"
 VERSION = "7.1.0b3"
@@ -44,7 +44,7 @@ setup(
     keywords=["Microsoft", "VSTS", "Team Services", "SDK", "AzureTfs", "AzureDevOps", "DevOps"],
     install_requires=REQUIRES,
     classifiers=CLASSIFIERS,
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     include_package_data=True,
     python_requires=">=3.7",
     long_description="Azure DevOps Python clients"


### PR DESCRIPTION
This package is broken in the latest version of setuptools, this PR fixes the issue and tests the patch on Python 3.12

