### PR TITLE
Updating get_pull_requests_by_project

### DIFF
--- a/azure-devops/azure/devops/released/git/git_client_base.py
+++ b/azure-devops/azure/devops/released/git/git_client_base.py
@@ -2069,7 +2069,7 @@ class GitClientBase(Client):
                               route_values=route_values)
         return self._deserialize('GitPullRequest', response)
 
-    def get_pull_requests_by_project(self, project, search_criteria, max_comment_length=None, skip=None, top=None):
+    def get_pull_requests_by_project(self, project, search_criteria=None, max_comment_length=None, skip=None, top=None):
         """GetPullRequestsByProject.
         Retrieve all pull requests matching a specified criteria.
         :param str project: Project ID or project name


### PR DESCRIPTION
Since the search_criteria is only optional, the base value `None` was added to the `search_criteria` parameter.